### PR TITLE
Fix index error on _id field

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ var mongoose = require('mongoose'),
     Schema = mongoose.Schema,
     autoIncrement = require('mongoose-auto-increment');
 
-var connection = mongoose.createConnection("mongodb://localhost/myDatabase");
+var connection = mongoose.connect("mongodb://localhost/myDatabase");
 
 autoIncrement.initialize(connection);
 

--- a/index.js
+++ b/index.js
@@ -56,14 +56,17 @@ exports.plugin = function (schema, options) {
       extend(settings, options);
     break;
   }
-
+  
   // Add properties for field in schema.
-  fields[settings.field] = {
-    type: Number,
-    unique: settings.unique,
-    require: true
-  };
-  schema.add(fields);
+  if (!schema.paths[settings.field]) {
+    fields[settings.field] = {
+      type: Number,
+      require: true
+    };
+    if (settings.field !== '_id')
+      fields[settings.field].unique = settings.unique,
+    schema.add(fields);
+  }
 
   // Find the counter for this model and the relevant field.
   IdentityCounter.findOne(


### PR DESCRIPTION
Don't set index on _id, because that index already exists (created by default)
Because of error, other fields not indexed:

var mongoose = require('mongoose');
mongoose.set('debug', true);
mongoose.connect('mongodb://localhost/test');

var schema = new mongoose.Schema({
  _id: { Number
    required: true,
    unique: true
  },
  secureId: {
    type: String,
    required: true,
    unique: true
  }
});

var User = mongoose.model('User', schema);
User.on('index', function() {
  return console.log(arguments);
});
