### PR TITLE
Fix index error on _id field

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,12 +57,16 @@ exports.plugin = function (schema, options) {
     break;
   }
 
+  if (settings.model == null)
+    throw new Error("model must be set");
+
   // Add properties for field in schema.
   fields[settings.field] = {
     type: Number,
-    unique: settings.unique,
     require: true
   };
+  if (settings.field !== '_id')
+    fields[settings.field].unique = settings.unique
   schema.add(fields);
 
   // Find the counter for this model and the relevant field.

--- a/test/test.js
+++ b/test/test.js
@@ -133,10 +133,17 @@ describe('mongoose-auto-increment', function () {
       name: String,
       dept: String
     });
+
+    (function() {
+      userSchema.plugin(autoIncrement.plugin);
+    }).should.throw(Error);
+
     userSchema.plugin(autoIncrement.plugin, { model: 'User', incrementBy: 5 });
     var User = connection.model('User', userSchema),
     user1 = new User({ name: 'Charlie', dept: 'Support' }),
     user2 = new User({ name: 'Charlene', dept: 'Marketing' });
+
+
 
     // Act
     async.series({
@@ -158,6 +165,9 @@ describe('mongoose-auto-increment', function () {
     }
 
   });
+
+
+
 
   describe('helper function', function () {
 


### PR DESCRIPTION
Don't set index on _id, because that index already exists (created by default)
Because of error, other fields not indexed:

```javascript
var mongoose = require('mongoose');
mongoose.set('debug', true);
mongoose.connect('mongodb://localhost/test');

var schema = new mongoose.Schema({
  _id: { 
    type: Number,
    required: true,
    unique: true
  },
  secureId: {
    type: String,
    required: true,
    unique: true
  }
});

var User = mongoose.model('User', schema);
User.on('index', function() {
  return console.log(arguments);
});
```