### PR TITLE
Update mongoose dependency from ~4.0.0 to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     "extend": "^2.0.0"
   },
   "peerDependencies": {
-    "mongoose": "~4.0.0"
+    "mongoose": "^4.0.0"
   },
   "devDependencies": {
     "async": "*",
     "chai": "*",
     "mocha": "*",
-    "mongoose": "~4.0.0"
+    "mongoose": "^4.0.0"
   },
   "keywords": [
     "mongoose",


### PR DESCRIPTION
The peerDependency version restriction currently prevents using the latest version of mongoose (4.1.10). This switches the semver prefix to a caret instead of a tilde so that any versions of mongoose within the 4.x.x range should be good. Resolves #40 